### PR TITLE
CT-1342: remove duplicated and early cleanup after unpublish

### DIFF
--- a/RCTOpenTokPublisherView.m
+++ b/RCTOpenTokPublisherView.m
@@ -102,18 +102,13 @@
 }
 
 - (void)pausePublish{
-    NSLog(@"pausePublish");
     OTError* error = nil;
     [_session unpublish:_publisher error:&error];
     if (error) {
         NSLog(@"publishing failed with error: (%@)", error);
     }
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self cleanupPublisher];
-    });
 }
 - (void)resumePublish{
-    NSLog(@"resumePublish");
     // for web we could preserve the publisher, but it doesnt seem to work here.
     // So we need to recreate the publisher
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/RCTOpenTokSessionManager.m
+++ b/RCTOpenTokSessionManager.m
@@ -27,8 +27,6 @@ RCT_EXPORT_METHOD(connect:(NSString *)apiKey sessionId:(NSString *)sessionId tok
 
   if (error) {
     NSLog(@"connect failed with error: (%@)", error);
-  } else {
-    NSLog(@"session created");
   }
 }
 


### PR DESCRIPTION
Also removing verbose debug logs, the idea would be use logs only non-normal conditions
